### PR TITLE
Fix trailing text in test scripts

### DIFF
--- a/test_final_classes.py
+++ b/test_final_classes.py
@@ -80,4 +80,3 @@ if __name__ == "__main__":
     else:
         print("❌ HAY PROBLEMAS DE REGISTRO")
     
-    return success 

--- a/test_final_panels.py
+++ b/test_final_panels.py
@@ -75,4 +75,3 @@ if __name__ == "__main__":
     else:
         print("❌ HAY PROBLEMAS DE REGISTRO")
     
-    return success 

--- a/test_final_registration.py
+++ b/test_final_registration.py
@@ -58,4 +58,3 @@ if __name__ == "__main__":
     else:
         print("❌ HAY PROBLEMAS DE REGISTRO")
     
-    return success 

--- a/test_final_simple.py
+++ b/test_final_simple.py
@@ -58,4 +58,3 @@ if __name__ == "__main__":
     else:
         print("❌ HAY PROBLEMAS DE REGISTRO")
     
-    return success 

--- a/test_registration.py
+++ b/test_registration.py
@@ -113,4 +113,3 @@ if __name__ == "__main__":
         if not imports_ok:
             print("   - Errores de importación detectados")
     
-    return syntax_ok and imports_ok 

--- a/test_registration_final.py
+++ b/test_registration_final.py
@@ -89,4 +89,3 @@ if __name__ == "__main__":
     else:
         print("❌ HAY PROBLEMAS DE REGISTRO")
     
-    return modules_ok and main_ok 

--- a/test_simple.py
+++ b/test_simple.py
@@ -77,4 +77,3 @@ if __name__ == "__main__":
     else:
         print("❌ HAY PROBLEMAS DE IMPORTACIÓN")
     
-    return success 


### PR DESCRIPTION
## Summary
- clean up trailing return statements in test scripts

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_687bf1f57d5c832eab497e47d2952a5e