### PR TITLE
Fix unregister_handler

### DIFF
--- a/handlers.py
+++ b/handlers.py
@@ -74,9 +74,11 @@ def register_handler():
         _handler_registered = True
 
 def unregister_handler():
+    """Remove the frame change handler if it was previously registered."""
+    global _handler_registered
     try:
-        # Ejemplo: solo remover si existe
-        if hasattr(bpy.app.handlers, 'persistent_handler'):
-            bpy.app.handlers.persistent_handler.remove()
+        if _handler_registered and frame_change_handler in bpy.app.handlers.frame_change_pre:
+            bpy.app.handlers.frame_change_pre.remove(frame_change_handler)
+            _handler_registered = False
     except Exception as e:
         print(f"[typeanimator] handlers.py error: {e}")


### PR DESCRIPTION
## Summary
- fix unregister_handler removal logic for frame_change_handler

## Testing
- `pytest -q` *(fails: module 'bpy' has no attribute 'types')*

------
https://chatgpt.com/codex/tasks/task_e_687bf4886038832e92493f226e909163